### PR TITLE
Чайник DK-1G

### DIFF
--- a/modules/tuya/docs/kettle_dyld4c_properties.json
+++ b/modules/tuya/docs/kettle_dyld4c_properties.json
@@ -1,0 +1,440 @@
+{
+  "modelId": "dyld4c",
+  "services": [
+    {
+      "actions": [],
+      "code": "",
+      "description": "",
+      "events": [],
+      "name": "默认服务",
+      "properties": [
+        {
+          "abilityId": 1,
+          "accessMode": "rw",
+          "code": "start",
+          "description": "【必选】控制设备启动暂停开关",
+          "extensions": {
+            "iconName": "icon-dp_play",
+            "attribute": "1024"
+          },
+          "name": "工作开关",
+          "typeSpec": {
+            "type": "bool"
+          }
+        },
+        {
+          "abilityId": 2,
+          "accessMode": "ro",
+          "code": "temp_current",
+          "description": "【非必选】当前温度显示，该DP点用于温标为摄氏度使用，未选择该DP点则不展示该功能",
+          "extensions": {
+            "iconName": "icon-dp_c",
+            "attribute": "1024"
+          },
+          "name": "当前温度-℃",
+          "typeSpec": {
+            "type": "value",
+            "max": 100,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "℃"
+          }
+        },
+        {
+          "abilityId": 3,
+          "accessMode": "ro",
+          "code": "temp_current_f",
+          "description": "【非必选】当前温度显示，该DP点用于温标为华氏度使用，未选择该DP点则不展示该功能",
+          "extensions": {
+            "iconName": "icon-dp_f",
+            "attribute": "1024"
+          },
+          "name": "当前温度-℉",
+          "typeSpec": {
+            "type": "value",
+            "max": 212,
+            "min": 32,
+            "scale": 0,
+            "step": 1,
+            "unit": "℉"
+          }
+        },
+        {
+          "abilityId": 4,
+          "accessMode": "rw",
+          "code": "temp_setting_quick_c",
+          "description": "【非必选】快速选择加热到目标温度选项，该DP点枚举值可增、减、改，但修改枚举值名称仅支持为数字，未选则不展示该功能。 如需要修改代表名称，可以前往第四步的拓展中心，多语言管理修改代表值，新增的枚举值所代表的的内容也是在多语言中修改代表值。",
+          "extensions": {
+            "iconName": "icon-set",
+            "attribute": "1024"
+          },
+          "name": "加热到目标温度（净水模式煮水）",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "45",
+              "60",
+              "85",
+              "90",
+              "100"
+            ]
+          }
+        },
+        {
+          "abilityId": 5,
+          "accessMode": "rw",
+          "code": "temp_setting_quick_f",
+          "description": "【非必选】快速选择加热到目标温度选项，该DP点枚举值可增、减、改，但修改枚举值名称仅支持为数字，未选则不展示该功能。 如需要修改代表名称，可以前往第四步的拓展中心，多语言管理修改代表值，新增的枚举值所代表的的内容也是在多语言中修改代表值。",
+          "extensions": {
+            "iconName": "icon-set",
+            "attribute": "1024"
+          },
+          "name": "加热到目标温度（净水模式）",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "113",
+              "140",
+              "185",
+              "194",
+              "212"
+            ]
+          }
+        },
+        {
+          "abilityId": 6,
+          "accessMode": "rw",
+          "code": "temp_boiling_quick_c",
+          "description": "【非必选】快速选择沸腾后冷却到目标温度选项，该DP点枚举值可增、减、改，但修改枚举值名称仅支持为数字，未选则不展示该功能。 如需要修改代表名称，可以前往第四步的拓展中心，多语言管理修改代表值，新增的枚举值所代表的的内容也是在多语言中修改代表值。",
+          "extensions": {
+            "iconName": "icon-wendu2",
+            "attribute": "1024"
+          },
+          "name": "沸腾后冷却到目标温度（自来水煮水）",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "45",
+              "60",
+              "85",
+              "90",
+              "100"
+            ]
+          }
+        },
+        {
+          "abilityId": 7,
+          "accessMode": "rw",
+          "code": "temp_boiling_quick_f",
+          "description": "【非必选】快速选择沸腾后冷却到目标温度选项，该DP点枚举值可增、减、改，但修改枚举值名称仅支持为数字，未选则不展示该功能。 如需要修改代表名称，可以前往第四步的拓展中心，多语言管理修改代表值，新增的枚举值所代表的的内容也是在多语言中修改代表值。",
+          "extensions": {
+            "iconName": "icon-a_function_fahrenhei",
+            "attribute": "1024"
+          },
+          "name": "沸腾后冷却到目标温度（自来水模式）",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "113",
+              "140",
+              "185",
+              "194",
+              "212"
+            ]
+          }
+        },
+        {
+          "abilityId": 8,
+          "accessMode": "rw",
+          "code": "temp_set",
+          "description": "【非必选】选择加热到目标温度选项，该DP点数值范围可修改，未选则不展示该功能。",
+          "extensions": {
+            "iconName": "icon-set",
+            "attribute": "1024"
+          },
+          "name": "净水模式多段定温",
+          "typeSpec": {
+            "type": "value",
+            "max": 100,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "℃"
+          }
+        },
+        {
+          "abilityId": 9,
+          "accessMode": "rw",
+          "code": "temp_set_f",
+          "description": "【非必选】选择加热到目标温度选项，该DP点数值范围可修改，未选则不展示该功能。",
+          "extensions": {
+            "iconName": "icon-dp_f",
+            "attribute": "1024"
+          },
+          "name": "温度设置（℉）",
+          "typeSpec": {
+            "type": "value",
+            "max": 212,
+            "min": 32,
+            "scale": 0,
+            "step": 1,
+            "unit": "℉"
+          }
+        },
+        {
+          "abilityId": 10,
+          "accessMode": "rw",
+          "code": "temp_boiling_c",
+          "description": "【非必选】选择沸腾后冷却到目标温度选项，该DP点数值范围可修改，未选则不展示该功能。",
+          "extensions": {
+            "iconName": "icon-wendu2",
+            "attribute": "1024"
+          },
+          "name": "沸腾后冷却到目标温度（℃）",
+          "typeSpec": {
+            "type": "value",
+            "max": 100,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "℃"
+          }
+        },
+        {
+          "abilityId": 11,
+          "accessMode": "rw",
+          "code": "temp_boiling_f",
+          "description": "【非必选】选择沸腾后冷却到目标温度选项，该DP点数值范围可修改，未选则不展示该功能。",
+          "extensions": {
+            "iconName": "icon-wendu2",
+            "attribute": "1024"
+          },
+          "name": "沸腾后冷却到目标温度（℉）",
+          "typeSpec": {
+            "type": "value",
+            "max": 212,
+            "min": 32,
+            "scale": 0,
+            "step": 1,
+            "unit": "℉"
+          }
+        },
+        {
+          "abilityId": 12,
+          "accessMode": "rw",
+          "code": "temp_unit_convert",
+          "description": "【非必选】温标切换开关选择，未选则不展示该功能。如果选这了该功能，必须选择℃和℉的相关搭配DP点",
+          "extensions": {
+            "iconName": "icon-dp_mode",
+            "attribute": "1024"
+          },
+          "name": "温标切换",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "c",
+              "f"
+            ]
+          }
+        },
+        {
+          "abilityId": 13,
+          "accessMode": "rw",
+          "code": "warm",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-dp_power2",
+            "attribute": "1024"
+          },
+          "name": "保温",
+          "typeSpec": {
+            "type": "bool"
+          }
+        },
+        {
+          "abilityId": 14,
+          "accessMode": "rw",
+          "code": "warm_time",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-dp_time3",
+            "attribute": "1024"
+          },
+          "name": "保温时间",
+          "typeSpec": {
+            "type": "value",
+            "max": 360,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "min"
+          }
+        },
+        {
+          "abilityId": 15,
+          "accessMode": "ro",
+          "code": "status",
+          "description": "【必选】设备上报工作状态，该DP点枚举值可增减，但不可修改枚举值名称，例如可以删除9，但是不能把9改为其他词，可以增加，仅支持增加数字，未选则不展示该功能。 默认： 1代表：待机中 2代表：加热中 3代表：冷却中 4代表：保温中 5代表：加热到目标温度 6代表：沸腾后冷却到目标温度 7代表：预留1 8代表：预留2 9代表：预留3 如需要修改代表名称，可以前往第四步的拓展中心，多语言管理修改代表值，新增的枚举值所代表的的内容也是在多语言中修改代表值。",
+          "extensions": {
+            "iconName": "icon-zhuangtai",
+            "attribute": "1024"
+          },
+          "name": "设备状态",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "standby",
+              "heating",
+              "cooling",
+              "warm",
+              "heating_temp",
+              "boiling_temp",
+              "reserve_1",
+              "reserve_2",
+              "reserve_3"
+            ]
+          }
+        },
+        {
+          "abilityId": 16,
+          "accessMode": "rw",
+          "code": "work_type",
+          "description": "【必选】不可修改、删除、增加枚举值。该DP点用于明确当前工作模式是什么，与所使用的温度设置DP点绑定上报。 例如： 用户选择了90℃直接加热快捷键 APP会下发：该DP点的setting_quick和对应温度的DP点； MCU需要上报：该DP点的setting_quick和对应温度的DP点；",
+          "extensions": {
+            "iconName": "icon-dp_mode",
+            "attribute": "1024"
+          },
+          "name": "工作类型",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "setting_quick",
+              "boiling_quick",
+              "temp_setting",
+              "temp_boiling"
+            ]
+          }
+        },
+        {
+          "abilityId": 17,
+          "accessMode": "rw",
+          "code": "countdown_set",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-dp_time2",
+            "attribute": "1152"
+          },
+          "name": "倒计时",
+          "typeSpec": {
+            "type": "enum",
+            "range": [
+              "cancel",
+              "1h",
+              "2h",
+              "3h",
+              "4h",
+              "5h",
+              "6h",
+              "7h",
+              "8h",
+              "9h",
+              "10h",
+              "11h",
+              "12h",
+              "13h",
+              "14h",
+              "15h",
+              "16h",
+              "17h",
+              "18h",
+              "19h",
+              "20h",
+              "21h",
+              "22h",
+              "23h",
+              "24h"
+            ]
+          }
+        },
+        {
+          "abilityId": 18,
+          "accessMode": "ro",
+          "code": "countdown_left",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-dp_time2",
+            "attribute": "1024"
+          },
+          "name": "倒计时剩余时间",
+          "typeSpec": {
+            "type": "value",
+            "max": 1440,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "min"
+          }
+        },
+        {
+          "abilityId": 19,
+          "accessMode": "ro",
+          "code": "fault",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-baojing",
+            "attribute": "1024"
+          },
+          "name": "故障告警",
+          "typeSpec": {
+            "type": "bitmap",
+            "label": [
+              "kettle_leave",
+              "lack_water"
+            ],
+            "maxlen": 2
+          }
+        },
+        {
+          "abilityId": 20,
+          "accessMode": "rw",
+          "code": "countdown",
+          "description": "",
+          "extensions": {
+            "iconName": "icon-dp_time2",
+            "attribute": "1024"
+          },
+          "name": "倒计时",
+          "typeSpec": {
+            "type": "value",
+            "max": 1440,
+            "min": 0,
+            "scale": 0,
+            "step": 1,
+            "unit": "min"
+          }
+        },
+        {
+          "abilityId": 101,
+          "accessMode": "rw",
+          "code": "fluoride",
+          "description": "",
+          "name": "除氯烧水",
+          "typeSpec": {
+            "type": "bool"
+          }
+        },
+        {
+          "abilityId": 102,
+          "accessMode": "rw",
+          "code": "xy",
+          "description": "",
+          "name": "消音（蜂鸣器声音）",
+          "typeSpec": {
+            "type": "bool"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/modules/tuya/tuya.class.php
+++ b/modules/tuya/tuya.class.php
@@ -2268,8 +2268,8 @@ class tuya extends module
                  $cmd_rec['DIVIDEDBY2']=1;
                } 
              } elseif ($device['TYPE']=='kettle') {
-                 $cmd_rec['ALIAS'] = DK_1G_KETTLE_DPS_TO_ALIAS[$command];
-                 if ($cmd_rec['ALIAS'] == "start") {
+                 $alias = $cmd_rec['ALIAS'] = DK_1G_KETTLE_DPS_TO_ALIAS[$command];
+                 if (in_array($alias, ["start", "warm", "xy", "fluoride"])) {
                      $cmd_rec['VALUE_TYPE'] = "bool";
                  }
              }

--- a/modules/tuya/tuya.class.php
+++ b/modules/tuya/tuya.class.php
@@ -11,6 +11,30 @@
 Define('TUYA_LOCAL_PORT', 9898);
 Define('TUYA_WEB','https://px1.tuyaeu.com');
 
+const DK_1G_KETTLE_DPS_TO_ALIAS = [
+    1 => "start",
+    2 => "temp_current",
+    3 => "temp_current_f",
+    4 => "temp_setting_quick_c",
+    5 => "temp_setting_quick_f",
+    6 => "temp_boiling_quick_c",
+    7 => "temp_boiling_quick_f",
+    8 => "temp_set",
+    9 => "temp_set_f",
+    10 => "temp_boiling_c",
+    11 => "temp_boiling_f",
+    12 => "temp_unit_convert",
+    13 => "warm",
+    14 => "warm_time",
+    15 => "status",
+    16 => "work_type",
+    17 => "countdown_set",
+    18 => "countdown_left",
+    19 => "fault",
+    20 => "countdown",
+    101 => "fluoride",
+    102 => "xy",
+];
 
 class tuya extends module
 {
@@ -1776,7 +1800,6 @@ class tuya extends module
             } else {
                $dsp_filled = 0;
             }
-         
             if ($dsp_filled == 0)  {
                foreach($device['dps'] as $key => $value) {
                   $cmd_rec = SQLSelectOne("SELECT * FROM tucommands WHERE DEVICE_ID=".(int)$rec['ID']." AND TITLE LIKE '".DBSafe($key)."'");
@@ -2244,6 +2267,11 @@ class tuya extends module
                } elseif ($command=='102') {
                  $cmd_rec['DIVIDEDBY2']=1;
                } 
+             } elseif ($device['TYPE']=='kettle') {
+                 $cmd_rec['ALIAS'] = DK_1G_KETTLE_DPS_TO_ALIAS[$command];
+                 if ($cmd_rec['ALIAS'] == "start") {
+                     $cmd_rec['VALUE_TYPE'] = "bool";
+                 }
              }
 
          
@@ -2429,7 +2457,13 @@ class tuya extends module
        $dev_id=substr($properties[0]['DEV_ID'],0,$mdev);
        if ($properties[0]['TITLE']=='state') $dps_name=substr($properties[0]['DEV_ID'],$mdev+1);
       } else {
-       if ($properties[0]['TITLE']=='state') $dps_name='1';
+       if ($properties[0]['TITLE']=='state') {
+           $dps_name='1';
+       }
+       $dp_id = array_reverse(DK_1G_KETTLE_DPS_TO_ALIAS)[$properties[0]['ALIAS']];
+       if ($dp_id) {
+           $dps_name = $dp_id;
+       }
        $dev_id=$properties[0]['DEV_ID'];
       }
 


### PR DESCRIPTION
+ локальное управление чайником DK-1G (Fiesta). 
+ тип устройства должен быть определен как kettle
+ свойство start - стартует нагрев до кипячения 100
+ temp_setting_quick_c - кипячение до заданной температуры: 45, 60, 85 
+ temp_boiling_quick_c - кипячение до 100 с последующим охлождением до заданной температуры : 45, 60, 85 
+ warm - включение подогрева
+ temp_set - выставление температуры
+ описание свойств добавлено в раздел docs.